### PR TITLE
Fix bug where files can not be scanned from context menu, add build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ To build this project without installing Visual Studio, follow these steps:
 2. Run `nuget restore` to gather the required dependencies
 3. Run `msbuild "VirusTotal Uploader.sln"`
 4. The compiled .exe is in `VirusTotalUploader/VirusTotal Uploader/VirusTotal Uploader/bin/Debug` along with its dependencies.
-    * The first time I build the project it gave a few warnings. Deleting the `VirusTotalUploader/VirusTotal Uploader/VirusTotal Uploader/bin` directory and rebuilding resulted in 0 warnings.
+    * The first time building the project after a change it may give a few warnings. Rebuilding without making more changes usually results in 0 warnings.
 
 You may now move and run `VirusTotal Uploader.exe` from anywhere you'd like, just as long as the accompaning files are in the same directory as the exe. You may also delete the `app.publish` directory along with its contents.
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,25 @@ Alternatively you can add VirusTotal Uploader to file content menu and click on 
 
 ![usage](https://i.imgur.com/2iGyilJ.gif)
 
+## Building
+To build this project without installing Visual Studio, follow these steps:
+
+**Setup**
+1. Download and install "Build Tools for Visual Studio" from https://visualstudio.microsoft.com/downloads/ (scroll down, it's under "All downloads")
+2. Run Visual Studio Installer. Under the "Individual components" tab check ".NET Framework 4.6.1 targeting pack"
+    * On the right, under "Installation details" it should show "MSBuild Tools" and "Individual components" with both of the previously selected components listed.
+3. Click the install button
+    * You should see "MSBuild.exe" in a path similar to `C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin`
+4. Download NuGet from https://www.nuget.org/downloads
+    * You want the recommended download from the left side under "Windows x86 Commandline"
+  
+**Build**
+1. Clone this repo and navigate to `VirusTotalUploader/VirusTotal Uploader/VirusTotal Uploader/`. You should see `VirusTotal Uploader.sln` in this directory.
+2. Run `nuget restore` to gather the required dependencies
+3. Run `msbuild "VirusTotal Uploader.sln"`
+4. The compiled .exe is in `VirusTotalUploader/VirusTotal Uploader/VirusTotal Uploader/bin/Debug` along with its dependencies.
+    * The first time I build the project it gave a few warnings, but deleting the `VirusTotalUploader/VirusTotal Uploader/VirusTotal Uploader/bin` and rebuilding resulted in 0 warnings.
+
 ## Contributing
 If you have any idea how to make this app better, please create pull request. If you find any bug, please create issue.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To build this project without installing Visual Studio, follow these steps:
 **Setup**
 1. Download and install "Build Tools for Visual Studio" from https://visualstudio.microsoft.com/downloads/ (scroll down, it's under "All downloads")
 2. Run Visual Studio Installer. Under the "Individual components" tab check ".NET Framework 4.6.1 targeting pack"
-    * On the right, under "Installation details" it should show "MSBuild Tools" and "Individual components" with both of the previously selected components listed.
+    * On the right, under "Installation details" it should show "MSBuild Tools" and "Individual components" with "C# and Visual Basic Roslyn compilers" and ".NET Framework 4.6.1 targeting pack" listed.
 3. Click the install button
     * You should see "MSBuild.exe" in a path similar to `C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin`
 4. Download NuGet from https://www.nuget.org/downloads
@@ -44,7 +44,9 @@ To build this project without installing Visual Studio, follow these steps:
 2. Run `nuget restore` to gather the required dependencies
 3. Run `msbuild "VirusTotal Uploader.sln"`
 4. The compiled .exe is in `VirusTotalUploader/VirusTotal Uploader/VirusTotal Uploader/bin/Debug` along with its dependencies.
-    * The first time I build the project it gave a few warnings, but deleting the `VirusTotalUploader/VirusTotal Uploader/VirusTotal Uploader/bin` and rebuilding resulted in 0 warnings.
+    * The first time I build the project it gave a few warnings. Deleting the `VirusTotalUploader/VirusTotal Uploader/VirusTotal Uploader/bin` directory and rebuilding resulted in 0 warnings.
+
+You may now move and run `VirusTotal Uploader.exe` from anywhere you'd like, just as long as the accompaning files are in the same directory as the exe. You may also delete the `app.publish` directory along with its contents.
 
 ## Contributing
 If you have any idea how to make this app better, please create pull request. If you find any bug, please create issue.

--- a/VirusTotal Uploader/VirusTotal Uploader/VirusTotal Uploader/Settings.cs
+++ b/VirusTotal Uploader/VirusTotal Uploader/VirusTotal Uploader/Settings.cs
@@ -1,5 +1,5 @@
 ﻿/*  Copyright (c) 2018 Samuel Tulach
- *  
+ *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
  *  the Free Software Foundation, either version 3 of the License, or
@@ -61,7 +61,7 @@ namespace VirusTotal_Uploader
         {
             MessageBox.Show("VirusTotal Uploader\n\n" + GetMD5() + "\n\n" + @"
 Copyright (c) 2018 Samuel Tulach
-    
+
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
@@ -160,7 +160,7 @@ along with this program. If not, see < https://www.gnu.org/licenses/>.","About V
                     regmenu.SetValue("", lang.GetString("Scan with VirusTotal"));
                 regcmd = Registry.ClassesRoot.CreateSubKey(Command);
                 if (regcmd != null)
-                    regcmd.SetValue("", System.Reflection.Assembly.GetEntryAssembly().Location + " \"%1\"");
+                    regcmd.SetValue("", "\"" + System.Reflection.Assembly.GetEntryAssembly().Location + "\" \"%1\"");
                 MessageBox.Show(lang.GetString("Added to content menu"), lang.GetString("Yeah!"), MessageBoxButtons.OK, MessageBoxIcon.Information);
             }
             catch (Exception ex)


### PR DESCRIPTION
Fixed a bug where files can not be scanned from the context menu. It seems to have been caused by spaces in the path of the directory where "VirusTotal Uploader.exe" is uploaded. The fix is surrounding the path to the exe with apostrophes in the registry key. I am unsure if this is the bug causing this issue or not: https://github.com/SamuelTulach/VirusTotalUploader/issues/5

Also added instruction on how to build the project without Visual Studio installed to the README.